### PR TITLE
Add support for Rails 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,17 @@ rvm:
   - 2.2
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile-rails.3.2.x
   - gemfiles/Gemfile-rails.4.0.x
   - gemfiles/Gemfile-rails.4.1.x
+  - gemfiles/Gemfile-rails.head
 matrix:
-  allow_failures:
-    - rvm: 2.2
-      gemfile: gemfiles/Gemfile-rails.3.2.x
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile-rails.head
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile-rails.head
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.head
 notifications:
   email: false
   slack:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,26 +2,26 @@ PATH
   remote: .
   specs:
     has_scope (0.6.0)
-      actionpack (>= 3.2, < 5)
-      activesupport (>= 3.2, < 5)
+      actionpack (>= 3.2, < 5.1)
+      activesupport (>= 3.2, < 5.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.1)
-      actionview (= 4.2.1)
-      activesupport (= 4.2.1)
+    actionpack (4.2.4)
+      actionview (= 4.2.4)
+      activesupport (= 4.2.4)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    actionview (4.2.1)
-      activesupport (= 4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.4)
+      activesupport (= 4.2.4)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    activesupport (4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -30,22 +30,22 @@ GEM
     builder (3.2.2)
     erubis (2.7.0)
     i18n (0.7.0)
-    json (1.8.2)
-    loofah (2.0.1)
+    json (1.8.3)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)
     mini_portile (0.6.2)
-    minitest (5.5.1)
+    minitest (5.8.2)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
@@ -65,3 +65,6 @@ DEPENDENCIES
   has_scope!
   mocha (~> 1.0.0)
   rake
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/Gemfile-rails.3.2.x
+++ b/gemfiles/Gemfile-rails.3.2.x
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'actionpack', '~> 3.2.0'
-gem 'activesupport', '~> 3.2.0'
-gem 'mocha', '~> 1.0.0', require: false
-gem 'rake'

--- a/gemfiles/Gemfile-rails.head
+++ b/gemfiles/Gemfile-rails.head
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'actionpack', github: 'rails/rails'
+gem 'activesupport', github: 'rails/rails'
+gem 'mocha', '~> 1.0.0', require: false
+gem 'rack', github: 'rack/rack'
+gem 'rake'

--- a/has_scope.gemspec
+++ b/has_scope.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
     'README.md'
   ]
 
-  s.add_runtime_dependency 'actionpack', '>= 3.2', '< 5'
-  s.add_runtime_dependency 'activesupport', '>= 3.2', '< 5'
+  s.add_runtime_dependency 'actionpack', '>= 4', '< 5.1'
+  s.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
 end

--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -3,7 +3,7 @@ module HasScope
 
   ALLOWED_TYPES = {
     :array   => [[ Array ]],
-    :hash    => [[ Hash ]],
+    :hash    => [[Hash, ActionController::Parameters]],
     :boolean => [[ Object ], -> v { TRUE_VALUES.include?(v) }],
     :default => [[ String, Numeric ]],
   }
@@ -147,6 +147,8 @@ module HasScope
       value.select { |v| v.present? }
     when Hash
       value.select { |k, v| normalize_blanks(v).present? }.with_indifferent_access
+    when ActionController::Parameters
+      value.select { |k, v| normalize_blanks(v).present? }.to_unsafe_h.with_indifferent_access
     else
       value
     end
@@ -201,5 +203,5 @@ end
 
 ActiveSupport.on_load :action_controller do
   include HasScope
-  helper_method :current_scopes
+  helper_method :current_scopes if respond_to?(:helper_method)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'mocha/mini_test'
 ENV['RAILS_ENV'] = 'test'
 
 require 'active_support'
+require 'active_support/core_ext/string/strip'
 require 'action_controller'
 require 'action_dispatch/middleware/flash'
 


### PR DESCRIPTION
The only pending change here is how to deal with the `ActionController::TestCase` deprecations without dropping support for older versions just because of the test suite. We could go 4.2+ only but the deprecations would still be around :tired_face:.

```
DEPRECATION WARNING: ActionController::TestCase HTTP request methods will accept only
keyword arguments in future Rails versions.

Examples:

get :show, params: { id: 1 }, session: { user_id: 1 }
process :update, method: :post, params: { id: 1 }
 (called from test_scope_is_not_called_if_blank at /Users/lucas/src/work/has_scope/test/has_scope_test.rb:154)
```