### PR TITLE
with_scope_model - Specify the model to which has_scope applies.

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -91,14 +91,14 @@ module HasScope
         self.scopes_configuration[scope] = self.scopes_configuration[scope].merge(options)
       end
     end
-  end
 
-  def with_scope_model(model_class, &block)
-    self.scopes_model_class = model_class
+    def with_scope_model(model_class, &block)
+      self.scopes_model_class = model_class
 
-    class_eval &block
+      class_eval &block
 
-    self.scopes_model_class = nil
+      self.scopes_model_class = nil
+    end
   end
 
   protected


### PR DESCRIPTION
Allows you to use `has_scope` even if the name of the controller breaks the Rails naming convention.

We have an AR model named `FooBar`, but the controller is named `FooAdmin::BarsController`. This arises because the AR model is in a Gem that was developed separately. `with_scope_model` was created as a way to work around these issues without having to restructure apps.

