### PR TITLE
Support Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ gemfile:
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.1.x
+  - gemfiles/Gemfile-rails.5.2.x
   - gemfiles/Gemfile-rails.head
 matrix:
   exclude:
     - rvm: 2.1
       gemfile: gemfiles/Gemfile-rails.5.1.x
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.2.x
   allow_failures:
     - gemfile: gemfiles/Gemfile-rails.head
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: ruby
 sudo: false
+before_install:
+  - gem update --system # https://github.com/travis-ci/travis-ci/issues/8978
+  - gem install bundler # use the very latest Bundler
 rvm:
   - 2.1
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
 gemfile:
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
   - 2.1
   - 2.2
 gemfile:
-  - Gemfile
   - gemfiles/Gemfile-rails.4.1.x
+  - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.head
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ gemfile:
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.head
+matrix:
+  allow_failures:
+    - gemfile: gemfiles/Gemfile-rails.head
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 rvm:
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
 gemfile:
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ rvm:
 gemfile:
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
+  - gemfiles/Gemfile-rails.5.1.x
   - gemfiles/Gemfile-rails.head
 matrix:
+  exclude:
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.1.x
   allow_failures:
     - gemfile: gemfiles/Gemfile-rails.head
 notifications:

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
 gem 'actionpack', '~> 4.2.0'
 gem 'activesupport', '~> 4.2.0'

--- a/gemfiles/Gemfile-rails.4.2.x.lock
+++ b/gemfiles/Gemfile-rails.4.2.x.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     has_scope (0.7.1)
-      actionpack (>= 4.1, < 5.2)
-      activesupport (>= 4.1, < 5.2)
+      actionpack (>= 4.1, < 6.0)
+      activesupport (>= 4.1, < 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -67,4 +67,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/gemfiles/Gemfile-rails.4.2.x.lock
+++ b/gemfiles/Gemfile-rails.4.2.x.lock
@@ -30,7 +30,7 @@ GEM
     builder (3.2.2)
     erubis (2.7.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)

--- a/gemfiles/Gemfile-rails.4.2.x.lock
+++ b/gemfiles/Gemfile-rails.4.2.x.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     has_scope (0.7.1)
       actionpack (>= 4.1, < 5.2)

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'actionpack', '~> 5.1.0'
+gem 'activesupport', '~> 5.1.0'
+gem 'mocha', '~> 1.0.0', require: false
+gem 'rake'

--- a/gemfiles/Gemfile-rails.5.1.x.lock
+++ b/gemfiles/Gemfile-rails.5.1.x.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: ..
+  specs:
+    has_scope (0.7.1)
+      actionpack (>= 4.1, < 6.0)
+      activesupport (>= 4.1, < 6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (5.1.6)
+      actionview (= 5.1.6)
+      activesupport (= 5.1.6)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.1.6)
+      activesupport (= 5.1.6)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.1.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    builder (3.2.3)
+    concurrent-ruby (1.0.5)
+    crass (1.0.4)
+    erubi (1.7.1)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    metaclass (0.0.4)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    mocha (1.0.0)
+      metaclass (~> 0.0.1)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    rack (2.0.4)
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
+    rake (12.3.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 5.1.0)
+  activesupport (~> 5.1.0)
+  has_scope!
+  mocha (~> 1.0.0)
+  rake
+
+BUNDLED WITH
+   1.16.1

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'actionpack', '~> 5.2.0'
+gem 'activesupport', '~> 5.2.0'
+gem 'mocha', '~> 1.0.0', require: false
+gem 'rake'

--- a/gemfiles/Gemfile-rails.5.2.x.lock
+++ b/gemfiles/Gemfile-rails.5.2.x.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: ..
+  specs:
+    has_scope (0.7.1)
+      actionpack (>= 4.1, < 6.0)
+      activesupport (>= 4.1, < 6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (5.2.0)
+      actionview (= 5.2.0)
+      activesupport (= 5.2.0)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.0)
+      activesupport (= 5.2.0)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    builder (3.2.3)
+    concurrent-ruby (1.0.5)
+    crass (1.0.4)
+    erubi (1.7.1)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    metaclass (0.0.4)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    mocha (1.0.0)
+      metaclass (~> 0.0.1)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    rack (2.0.4)
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
+    rake (12.3.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 5.2.0)
+  activesupport (~> 5.2.0)
+  has_scope!
+  mocha (~> 1.0.0)
+  rake
+
+BUNDLED WITH
+   1.16.1

--- a/has_scope.gemspec
+++ b/has_scope.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.7'
 
-  s.add_runtime_dependency 'actionpack', '>= 4.1', '< 5.2'
-  s.add_runtime_dependency 'activesupport', '>= 4.1', '< 5.2'
+  s.add_runtime_dependency 'actionpack', '>= 4.1', '< 6.0'
+  s.add_runtime_dependency 'activesupport', '>= 4.1', '< 6.0'
 end


### PR DESCRIPTION
Closes #91, which appears abandoned. Resolves #96.

The only material change is the gemspec dependency on actionpack and activesupport but travis.yml needed various updates.